### PR TITLE
Fix issue on monitor disconnect and in udev-rule

### DIFF
--- a/data/udev/90-HOTPLUG_display-visor.rules
+++ b/data/udev/90-HOTPLUG_display-visor.rules
@@ -1,1 +1,1 @@
-ACTION=="change", SUBSYSTEM=="drm", ENV{HOTPLUG}=="1", RUN+="pkill -RTMIN+5 display-visor"
+ACTION=="change", SUBSYSTEM=="drm", ENV{HOTPLUG}=="1", RUN+="/usr/bin/pkill -x -RTMIN+5 display-visor"

--- a/src/display-visor
+++ b/src/display-visor
@@ -94,6 +94,8 @@ declare_outputs ()
         if [ "connected" == "$status" ]; then
             echo "$prefix $dev connected"
             declare -gA $dev="yes"
+        else
+            unset $dev
         fi
     done <<< "$devices"
 }


### PR DESCRIPTION
When disconnecting a monitor on my system, display-visor didn't recognize the new setting as the monitor was still listed in /sys/class/drm (with status != connected) when the udev rule triggered display-visor. This issue is fixed by this commit.

This commit also adds absolute path for pkill in udev-rule.
